### PR TITLE
Componentize Home page

### DIFF
--- a/src/pages/home/FestivalSection/FestivalSection.tsx
+++ b/src/pages/home/FestivalSection/FestivalSection.tsx
@@ -1,0 +1,27 @@
+import oneFestival from '@image/one-festival.svg';
+import vetMontanha from '@image/vet-montanha.svg';
+
+import Button from '@/components/Button';
+
+export default function FestivalSection() {
+  return (
+    <section className="bg-yellow-500 mt-10 rounded-[20px] py-8 mb-20">
+      <div className="flex flex-col md:flex-row justify-center mb-5">
+        <div className="flex justify-center">
+          <img className="w-40 md:w-64 mb-5" src={oneFestival} alt="Banner do One Festival MBL" />
+        </div>
+        <div className="flex flex-col gap-3 justify-center items-center px-4 md:px-12 md:py-2">
+          <h3 className="uppercase">O primeiro festival do MBL</h3>
+          <p className="medium-body text-center w-full md:w-[470px] text-gray-300">
+            O tradicional Congresso Nacional do MBL agora é Festival: mais ideias, mais cultura, mais ação. Prepare-se
+            para um evento que vai além da política!
+          </p>
+          <p className="medium-body md:block hidden">Dia 29 de Novembro | Local: Komplexo Tempo</p>
+          <p className="medium-body w-44 text-center block md:hidden">Dia 29 de Novembro Local: Komplexo Tempo</p>
+          <Button text="Garantir Meu Ingresso Agora" link="#" />
+        </div>
+      </div>
+      <img className="md:mt-0 mt-8" src={vetMontanha} alt="Ilustração de montanha" />
+    </section>
+  );
+}

--- a/src/pages/home/HeroSection/HeroSection.tsx
+++ b/src/pages/home/HeroSection/HeroSection.tsx
@@ -1,0 +1,29 @@
+import homeHeroBg from '@image/home-hero-bg.avif';
+import heroHomeMenbersOfMbl from '@image/hero-home-menbers-of-mbl.avif';
+import heroHomeMenbersOfMblMobile from '@image/hero-image-mobile.avif';
+
+import VideoHomeHero from '../VideoHero/VideoHomeHero';
+
+export default function HeroSection() {
+  return (
+    <section className="flex flex-col items-center">
+      <div
+        className="lg:w-full w-screen max-w-none relative left-1/2 -translate-x-1/2 mt-36 hero-home"
+        style={{ backgroundImage: `url(${homeHeroBg})` }}
+      >
+        <img className="lg:block hidden lg:w-3/4 lg:mt-[-90px]" src={heroHomeMenbersOfMbl} alt="Membros do MBL" />
+        <img className="block lg:hidden mt-[-80px] lg:mt-0" src={heroHomeMenbersOfMblMobile} alt="Membros do MBL" />
+      </div>
+
+      <VideoHomeHero />
+
+      <div className="text-blue-200 flex flex-col justify-center text-center">
+        <h1 className="mb-5">Juntos pelo Brasil que Sonhamos!</h1>
+        <p className="big-body max-w-[559px] self-center">
+          Unimos pessoas que desejam marcar sua geração e entregamos a elas oportunidades reais de agir hoje, para
+          começarem a construir um legado único para o seu país, em cada uma das nossas iniciativas.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -1,91 +1,23 @@
 
-import homeHeroBg from '@image/home-hero-bg.avif';
-import heroHomeMenbersOfMbl from '@image/hero-home-menbers-of-mbl.avif';
-import heroHomeMenbersOfMblMobile from '@image/hero-image-mobile.avif';
-import oneFestival from '@image/one-festival.svg';
-import vetMontanha from '@image/vet-montanha.svg';
-
-import VideoHomeHero from './VideoHero/VideoHomeHero';
-import ImageGrid from './ImageGrid/ImageGrid'
-import InfiniteSlider from './InfiniteSlider/InfiniteSlider';
-import UltimasNoticiasGrid from './UltimasNoticiasGrid/UltimasNoticiasGrid'
-import TimelineMbl from './TimelineMbl/TimelineMbl'
-import LojaMbl from './LojaMbl/LojaMbl'
-
-import Button from '@/components/Button';
+import ImageGrid from './ImageGrid/ImageGrid';
+import HeroSection from './HeroSection/HeroSection';
+import FestivalSection from './FestivalSection/FestivalSection';
+import PortaVozesSection from './PortaVozesSection/PortaVozesSection';
+import UltimasNoticiasSection from './UltimasNoticiasSection/UltimasNoticiasSection';
+import TimelineSection from './TimelineSection/TimelineSection';
+import LojaSection from './LojaSection/LojaSection';
 
 export default function Home() {
   return (
     <div className="container mt-10">
       <div>
-        <div
-          className=" lg:w-full w-screen max-w-none relative left-1/2 -translate-x-1/2 mt-36 hero-home"
-          style={{
-            backgroundImage: `url(${homeHeroBg})`,
-          }}
-        >
-          <img className="lg:block hidden lg:w-3/4 lg:mt-[-90px]" src={heroHomeMenbersOfMbl} alt="Membros do MBL" />
-          <img className="block lg:hidden mt-[-80px] lg:mt-0" src={heroHomeMenbersOfMblMobile} alt="Membros do MBL" />
-
-        </div>
-
-        <VideoHomeHero />
-
-        <div className="text-blue-200 flex flex-col justify-center text-center">
-          <h1 className='mb-5'>Juntos pelo Brasil que Sonhamos!</h1>
-          <p className="big-body max-w-[559px] self-center">
-            Unimos pessoas que desejam marcar sua geração e entregamos a elas oportunidades
-            reais de agir hoje, para começarem a construir um legado único para o seu país, em cada uma das
-            nossas iniciativas.
-          </p>
-        </div>
-
-        <section className="bg-yellow-500 mt-10 rounded-[20px] py-8 mb-20">
-          <div className="flex flex-col md:flex-row justify-center mb-5">
-            <div className="flex justify-center">
-          <img className="w-40 md:w-64 mb-5" src={oneFestival} alt="Banner do One Festival MBL" />
-            </div>
-            <div className="flex flex-col gap-3 justify-center items-center px-4 md:px-12 md:py-2">
-              <h3 className="uppercase">O primeiro festival do MBL</h3>
-              <p className="medium-body text-center w-full md:w-[470px] text-gray-300">
-                O tradicional Congresso Nacional do MBL agora é Festival: mais ideias, mais cultura, mais ação.
-                Prepare-se para um evento que vai além da política!
-              </p>
-              <p className="medium-body md:block hidden">Dia 29 de Novembro | Local: Komplexo Tempo</p>
-              <p className="medium-body w-44 text-center block md:hidden">
-                Dia 29 de Novembro  Local: Komplexo Tempo
-              </p>
-              <Button text="Garantir Meu Ingresso Agora" link="#" />
-            </div>
-          </div>
-          <img className="md:mt-0 mt-8" src={vetMontanha} alt="Ilustração de montanha" />
-        </section>
-
+        <HeroSection />
+        <FestivalSection />
         <ImageGrid />
-
-        <section className='flex flex-col mt-20'>
-          <h2 className='text-center'>Nossos Porta-vozes</h2>
-          <InfiniteSlider />
-          <Button className='mt-5 self-center' text="Conheça todos porta-vozes" link="#" />
-        </section>
-
-        <section className='mt-20'>
-          <h2 className='text-center mb-8'>Últimas notícias sobre o movimento</h2>
-
-          <UltimasNoticiasGrid />
-        </section>
-
-        <section className='mt-20'>
-            <TimelineMbl />
-        </section>
-
-        <section className='mt-20'>
-            <h2 className='mb-5 text-center'>Loja MBL</h2>
-            <LojaMbl/>
-            <div className='flex justify-center'>
-              <Button className='mt-10' text="Ir para Loja MBL" link="#" />
-            </div>
-        </section>
+        <PortaVozesSection />
+        <UltimasNoticiasSection />
+        <TimelineSection />
+        <LojaSection />
       </div>
     </div>
   );

--- a/src/pages/home/LojaSection/LojaSection.tsx
+++ b/src/pages/home/LojaSection/LojaSection.tsx
@@ -1,0 +1,14 @@
+import LojaMbl from '../LojaMbl/LojaMbl';
+import Button from '@/components/Button';
+
+export default function LojaSection() {
+  return (
+    <section className="mt-20">
+      <h2 className="mb-5 text-center">Loja MBL</h2>
+      <LojaMbl />
+      <div className="flex justify-center">
+        <Button className="mt-10" text="Ir para Loja MBL" link="#" />
+      </div>
+    </section>
+  );
+}

--- a/src/pages/home/PortaVozesSection/PortaVozesSection.tsx
+++ b/src/pages/home/PortaVozesSection/PortaVozesSection.tsx
@@ -1,0 +1,12 @@
+import InfiniteSlider from '../InfiniteSlider/InfiniteSlider';
+import Button from '@/components/Button';
+
+export default function PortaVozesSection() {
+  return (
+    <section className="flex flex-col mt-20">
+      <h2 className="text-center">Nossos Porta-vozes</h2>
+      <InfiniteSlider />
+      <Button className="mt-5 self-center" text="Conheça todos porta-vozes" link="#" />
+    </section>
+  );
+}

--- a/src/pages/home/TimelineSection/TimelineSection.tsx
+++ b/src/pages/home/TimelineSection/TimelineSection.tsx
@@ -1,0 +1,9 @@
+import TimelineMbl from '../TimelineMbl/TimelineMbl';
+
+export default function TimelineSection() {
+  return (
+    <section className="mt-20">
+      <TimelineMbl />
+    </section>
+  );
+}

--- a/src/pages/home/UltimasNoticiasSection/UltimasNoticiasSection.tsx
+++ b/src/pages/home/UltimasNoticiasSection/UltimasNoticiasSection.tsx
@@ -1,0 +1,10 @@
+import UltimasNoticiasGrid from '../UltimasNoticiasGrid/UltimasNoticiasGrid';
+
+export default function UltimasNoticiasSection() {
+  return (
+    <section className="mt-20">
+      <h2 className="text-center mb-8">Últimas notícias sobre o movimento</h2>
+      <UltimasNoticiasGrid />
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- split Home page into multiple components
- create components for hero, festival, spokespersons, news, timeline, and store sections

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run lint:scss` *(fails: stylelint not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858cd1f89688324a3491a899faac137